### PR TITLE
Fix SQL injection in user lookup functions

### DIFF
--- a/DCBUser.pm
+++ b/DCBUser.pm
@@ -41,7 +41,7 @@ sub user_init() {
 # Whenever we're dealing with logins or logouts we need the user data from the database.
 sub user_load_by_mail($) {
   my $mail = shift;
-  my %where = ('mail' => { -like => [$mail] });
+  my %where = ('mail' => $mail);
   my @fields = ('*');
   my $userh = DCBDatabase::db_select('users', \@fields, \%where);
 
@@ -56,7 +56,7 @@ sub user_load_by_mail($) {
 # Whenever we're dealing with logins or logouts we need the user data from the database.
 sub user_load_by_name($) {
   my $name = shift;
-  my %where = ('name' => { -like => [$name] });
+  my %where = ('name' => $name);
   my @fields = ('*');
   my $userh = DCBDatabase::db_select('users', \@fields, \%where);
 


### PR DESCRIPTION
## Summary
- Replace `-like` with exact match in `user_load_by_name()` and `user_load_by_mail()`
- These functions load a specific user and should never use wildcard matching
- Prevents SQL wildcard injection via `%` and `_` characters in usernames/emails

## Test plan
- [ ] User login still works correctly
- [ ] User lookup by name returns exact matches only
- [ ] User lookup by email returns exact matches only

🤖 Generated with [Claude Code](https://claude.com/claude-code)