### PR TITLE
Fix SQL injection in search command

### DIFF
--- a/commands/search.pm
+++ b/commands/search.pm
@@ -32,9 +32,12 @@ sub main {
     $message = "Search results: \n";
     my @fields = ('time', 'uid', 'chat');
 
+    # Escape SQL wildcard characters in user input
+    (my $escaped_search = $search) =~ s/([%_\\])/\\$1/g;
+
     # Ensure we do not search for what the bot puts back into chat
     my %where = (
-      chat => { '-like', '%' . $search . '%' },
+      chat => { '-like', '%' . $escaped_search . '%' },
       uid => { '!=', 2 }
     );
     my $order = {-desc => 'hid'};


### PR DESCRIPTION
## Summary
- Escape SQL wildcard characters (`%`, `_`, `\`) in user-supplied search input before passing to `-like` query
- Prevents users from injecting wildcard patterns to manipulate search results

## Test plan
- [ ] Search with normal text works as before
- [ ] Search containing `%` or `_` characters treats them as literals

🤖 Generated with [Claude Code](https://claude.com/claude-code)