### PR TITLE
Fix glob injection in registry rebuild

### DIFF
--- a/DCBCommon.pm
+++ b/DCBCommon.pm
@@ -105,6 +105,13 @@ sub registry_remove {
 sub registry_rebuild {
   my $command = shift;
   $command ||= '*';
+
+  # Validate command name to prevent glob injection (allow only '*' for rebuild-all, or safe command names)
+  if ($command ne '*' && $command !~ /^[\w-]+$/) {
+    warn "Invalid command name: $command";
+    return;
+  }
+
   my %where = ();
 
   if ($command !~ /^\*$/) {


### PR DESCRIPTION
## Summary
- Validate command names in `registry_rebuild()` to only allow alphanumeric characters, underscores, and hyphens
- The wildcard `*` is still allowed for full registry rebuilds
- Prevents glob metacharacters from matching unintended files on the filesystem

## Test plan
- [ ] Full registry rebuild (`*`) still works
- [ ] Loading a specific valid command still works
- [ ] Command names with special characters are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)