### PR TITLE
Replace unsafe Storable::thaw with JSON deserialization

### DIFF
--- a/DCBCommon.pm
+++ b/DCBCommon.pm
@@ -9,7 +9,8 @@ use DateTime::Duration;
 use DateTime::Format::Duration;
 use Number::Bytes::Human;
 use YAML::AppConfig;
-use Storable qw(freeze thaw dclone);
+use Storable qw(dclone);
+use JSON qw(encode_json decode_json);
 use Module::Load;
 use Exporter;
 our @ISA= qw(Exporter);
@@ -71,14 +72,14 @@ sub registry_add {
   my $command = shift;
   $DCBCommon::registry->{commands}->{$command->{name}} = $command;
   if ($command->{alias}) {
-    my $aliases = thaw($command->{alias});
-    foreach (@$$aliases) {
+    my $aliases = decode_json($command->{alias});
+    foreach (@$aliases) {
       $DCBCommon::registry->{commands}->{$_} = dclone($command);
     }
   }
   if ($command->{hooks}) {
-    my $hooks = thaw($command->{hooks});
-    foreach (@$$hooks) {
+    my $hooks = decode_json($command->{hooks});
+    foreach (@$hooks) {
       $DCBCommon::registry->{hooks}->{$_}->{$command->{name}} = $command->{name};
     }
   }
@@ -88,14 +89,14 @@ sub registry_remove {
   my $command = shift;
   delete($DCBCommon::registry->{commands}->{$command->{name}});
   if ($command->{alias}) {
-    my $aliases = thaw($command->{alias});
-    foreach (@$$aliases) {
+    my $aliases = decode_json($command->{alias});
+    foreach (@$aliases) {
       delete($DCBCommon::registry->{commands}->{$_});
     }
   }
   if ($command->{hooks}) {
-    my $hooks = thaw($command->{hooks});
-    foreach (@$$hooks) {
+    my $hooks = decode_json($command->{hooks});
+    foreach (@$hooks) {
       delete($DCBCommon::registry->{hooks}->{$_}->{$command->{name}});
     }
   }
@@ -167,8 +168,8 @@ sub commands_load_commands {
         'status' => 1,
         'system' => $yaml->{config}->{system},
         'permissions' => DCBUser::user_permissions(@{ $yaml->{config}->{permissions} }),
-        'alias' => $yaml->{config}->{alias} ? freeze( \$yaml->{config}->{alias} ) : '',
-        'hooks' => $yaml->{config}->{hooks} ? freeze( \$yaml->{config}->{hooks} ) : '',
+        'alias' => $yaml->{config}->{alias} ? encode_json( $yaml->{config}->{alias} ) : '',
+        'hooks' => $yaml->{config}->{hooks} ? encode_json( $yaml->{config}->{hooks} ) : '',
       );
       DCBDatabase::db_insert('registry', \%fields);
       registry_add(\%fields);


### PR DESCRIPTION
## Summary
- Replace `Storable::freeze`/`thaw` with `JSON::encode_json`/`decode_json` for serializing command aliases and hooks
- `Storable::thaw()` can execute arbitrary code if database contents are tampered with; JSON is immune to this class of attack
- `Storable::dclone` is retained for in-memory deep copying which is safe

## Test plan
- [ ] Bot starts up and loads command registry
- [ ] Commands with aliases work correctly
- [ ] Commands with hooks are triggered properly
- [ ] Note: existing database registry entries will need to be rebuilt (`registry_rebuild`) after this change since the serialization format changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)