### PR TITLE
Validate command names before module loading

### DIFF
--- a/DCBCommon.pm
+++ b/DCBCommon.pm
@@ -199,6 +199,12 @@ sub commands_run_command {
   my $params = shift;
   my $commandname = $command->{name};
 
+  # Validate command name to prevent arbitrary module loading
+  if ($commandname !~ /^[\w]+$/) {
+    warn "Invalid command name refused for loading: $commandname";
+    return;
+  }
+
   if ($command->{status}) {
     # if it's already loaded, don't load it.
     if (!$INC{$commandname . '.pm'}) {


### PR DESCRIPTION
## Summary
- Add validation that command names contain only word characters before passing to `Module::Load::load`
- Prevents potential arbitrary module loading if the command registry is compromised or contains unexpected values

## Test plan
- [ ] Normal commands still load and execute correctly
- [ ] Command names with special characters are rejected with a warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)