### PR TITLE
Fix command injection in update command

### DIFF
--- a/commands/update.pm
+++ b/commands/update.pm
@@ -7,12 +7,17 @@ use lib "$FindBin::Bin/..";
 use IPC::System::Simple qw(capture);
 use DCBSettings;
 use DCBCommon;
+use Cwd;
 
 sub main {
   my $command = shift;
   my $user = shift;
   my $output = '';
-  $output = capture("cd $DCBSettings::cwd ; git pull origin $DCBSettings::config->{version};");
+  # Use list form to prevent shell injection via config values
+  my $old_dir = Cwd::getcwd();
+  chdir($DCBSettings::cwd) or die "Cannot chdir to $DCBSettings::cwd: $!";
+  $output = capture("git", "pull", "origin", $DCBSettings::config->{version});
+  chdir($old_dir) or die "Cannot chdir back to $old_dir: $!";
   # temporarily removing the git log from the output as first time clones will not be able to run it
   #; " . 'git log @{1}..  --oneline');
   chomp($output);


### PR DESCRIPTION
## Summary
- Replace shell-interpolated string in `capture()` with list-form invocation
- Use `chdir()` instead of shell `cd` to change directory
- Prevents shell metacharacter injection via config values (`cwd`, `version`)

## Test plan
- [ ] Update command still pulls latest code from git
- [ ] Config values with special characters don't cause shell execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)