### PR TITLE
Fix URL injection in Google search command

### DIFF
--- a/commands/google.pm
+++ b/commands/google.pm
@@ -7,6 +7,7 @@ use FindBin;
 use lib "$FindBin::Bin/..";
 use Switch;
 use DCBCommon;
+use URI::Escape;
 
 sub main{
   my $command = shift;
@@ -21,10 +22,7 @@ sub main{
   if ($argNo > 10) {
     $message = "Too many search parameters. Try a something shorter. Or, you know, just open a web browser.";
   } else {
-    $message = "http://www.google.com/search?q=";
-    foreach (@args) {
-      $message .= $_ . "+";
-    }
+    $message = "http://www.google.com/search?q=" . join("+", map { uri_escape($_) } @args);
   }
   
   


### PR DESCRIPTION
## Summary
- URL-encode user search terms using `URI::Escape` before embedding in Google search URL
- Prevents URL injection via special characters (`&`, `#`, `=`, etc.) in search input

## Test plan
- [ ] Normal search queries still produce valid Google URLs
- [ ] Search terms with special characters are properly encoded

🤖 Generated with [Claude Code](https://claude.com/claude-code)