### PR TITLE
Add protection for sensitive config keys

### DIFF
--- a/commands/config.pm
+++ b/commands/config.pm
@@ -9,6 +9,9 @@ use YAML::AppConfig;
 use DCBSettings;
 use DCBCommon;
 
+# Config keys that cannot be modified via chat commands
+my @PROTECTED_KEYS = qw(db jabber commandPath);
+
 sub main {
   my $command = shift;
   my $user = shift;
@@ -32,13 +35,18 @@ sub main {
       }
     }
     elsif ($op =~ /^set$/) {
-      # TODO put in message confirmation here.
-      if (DCBSettings::config_set($variable, $value)) {
+      if (grep { $_ eq $variable } @PROTECTED_KEYS) {
+        $message = "Cannot modify protected config key: $variable";
+      }
+      elsif (DCBSettings::config_set($variable, $value)) {
         $message = "$variable set to $value";
       }
     }
     elsif ($op =~ /^delete$/) {
-      if (DCBSettings::config_delete($variable)) {
+      if (grep { $_ eq $variable } @PROTECTED_KEYS) {
+        $message = "Cannot delete protected config key: $variable";
+      }
+      elsif (DCBSettings::config_delete($variable)) {
         $message = "$variable deleted";
       }
     }


### PR DESCRIPTION
## Summary
- Add a list of protected config keys (`db`, `jabber`, `commandPath`) that cannot be modified or deleted via chat commands
- Prevents admin users from accidentally or maliciously modifying database connection or other critical settings through the bot interface

## Test plan
- [ ] Normal config get/set/delete still works for non-protected keys
- [ ] Attempting to set `db` returns an error message
- [ ] Attempting to delete `jabber` returns an error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)