### PR TITLE
Add file permission check for config files

### DIFF
--- a/DCBSettings.pm
+++ b/DCBSettings.pm
@@ -21,9 +21,17 @@ sub config_load {
   my $config = shift // $config_file;
   our ( $settings, $cwd, $suffix ) = fileparse( abs_path(__FILE__) );
 
+  # Check file permissions - warn if config is readable by group/others
+  my $config_path = $cwd . $config;
+  my $mode = (stat($config_path))[2];
+  if (defined $mode && ($mode & 044)) {
+    warn "WARNING: Config file $config_path is readable by group/others. "
+       . "Consider running: chmod 600 $config_path\n";
+  }
+
   # Create a new YAML object and get the config settings from file
   # Nested variables may be used: $config->{variables}->{timezone}
-  return YAML::AppConfig->new( file => $cwd . $config );
+  return YAML::AppConfig->new( file => $config_path );
 }
 
 sub config_set {


### PR DESCRIPTION
## Summary
- Check config file permissions on load and warn if file is readable by group or others
- Config files may contain database credentials, API keys, and Jabber passwords
- Suggests `chmod 600` to restrict access to owner only

## Test plan
- [ ] Bot starts normally with properly restricted config file
- [ ] Warning is emitted when config file has overly permissive permissions
- [ ] Config loading still works regardless of permissions (warning only, not blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)