### PR TITLE
Fix unanchored regex in username validation

### DIFF
--- a/DCBUser.pm
+++ b/DCBUser.pm
@@ -194,7 +194,7 @@ sub user_invalid_name($) {
   if (length($name) > $DCBSettings::config->{username_max_length}) {
     push(@errors, "Name length exceeds maximum of $DCBSettings::config->{username_max_length}");
   }
-  if (($name !~ /[\w-]+/) || ($name =~ /[\\\/]/)) {
+  if ($name !~ /^[\w-]+$/) {
     push(@errors, "Name contains illegal characters. Letters, numbers, underscores and hyphens only.");
   }
   if (lc($name) eq lc($DCBSettings::config->{botname}) || lc($name) eq lc($DCBSettings::config->{username_anonymous})) {


### PR DESCRIPTION
## Summary
- Anchor the username validation regex with `^` and `$` to validate the entire string
- Previously, a name like `valid<script>` would pass because the unanchored pattern found a partial match on `valid`
- Remove redundant backslash/forward-slash check (covered by the anchored character class)

## Test plan
- [ ] Valid usernames (letters, numbers, underscores, hyphens) are accepted
- [ ] Usernames with special characters like `<`, `>`, `&`, spaces are rejected
- [ ] Edge cases: empty string, single character names

🤖 Generated with [Claude Code](https://claude.com/claude-code)