### PR TITLE
Fix logic error in toggle command status check

### DIFF
--- a/commands/toggle.pm
+++ b/commands/toggle.pm
@@ -15,7 +15,7 @@ sub main {
   my $status = @chatarray ? shift(@chatarray) : '';
   my $message = 'Could not set status';
 
-  if ($togglecommand && $DCBCommon::registry->{commands}->{$togglecommand} && ($status || $status =~ 0)) {
+  if ($togglecommand && $DCBCommon::registry->{commands}->{$togglecommand} && (defined($status) && length($status))) {
     $DCBCommon::registry->{commands}->{$togglecommand}->{status} = $status;
     my %fields = (
     'status' => $status,


### PR DESCRIPTION
## Summary
- Fix incorrect use of `=~` (regex match) instead of equality check for status value
- `$status =~ 0` was using regex matching instead of checking if status equals 0
- Replace with `defined($status) && length($status)` to properly handle both truthy values and `0`

## Test plan
- [ ] Toggle command works with status `1` (enable)
- [ ] Toggle command works with status `0` (disable)
- [ ] Toggle command rejects empty status

🤖 Generated with [Claude Code](https://claude.com/claude-code)