### PR TITLE
Fix missing module prefix in stats timer

### DIFF
--- a/commands/stats.pm
+++ b/commands/stats.pm
@@ -79,7 +79,7 @@ sub timer {
   my $stats = clone ($DCBCommon::COMMON->{stats}->{hubstats});
   delete($stats->{sid});
   $stats->{time} = time();
-  db_insert('stats', $stats);
+  DCBDatabase::db_insert('stats', $stats);
   return;
 }
 


### PR DESCRIPTION
## Summary
- Add `DCBDatabase::` prefix to `db_insert()` call in `stats::timer()`
- All other database calls in the file use the full prefix; this was inconsistent
- Prevents potential breakage if export behavior changes

## Test plan
- [ ] Stats timer still inserts records correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)