### PR TITLE
Fix incorrect regex in ban time validation

### DIFF
--- a/commands/ban.pm
+++ b/commands/ban.pm
@@ -52,7 +52,7 @@ sub main {
     my $bantime = @chatarray ? shift(@chatarray) : '';
     # The bot chokes when the bantime is too large so we need to
     # limit the length to ensure it isn't too big.
-    if ($bantime =~ /^\d+([s|m|h|d|w|y])?$/) {
+    if ($bantime =~ /^\d+([smhdwy])?$/) {
       if (length(scalar($bantime)) >= 5) {
         @return = (
           {


### PR DESCRIPTION
## Summary
- Remove erroneous pipe `|` characters from regex character class `[s|m|h|d|w|y]`
- Inside `[]`, pipe is a literal character not an alternation operator
- The old regex would incorrectly accept `|` as a valid time unit suffix

## Test plan
- [ ] Ban times like `30m`, `2h`, `7d` still work
- [ ] Plain numeric ban times like `300` still work
- [ ] Input containing `|` character is no longer accepted as valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)