### PR TITLE
Fix missing semicolons causing syntax errors

### DIFF
--- a/commands/first.pm
+++ b/commands/first.pm
@@ -28,7 +28,7 @@ sub main {
       $message = "First line spoken by $first_user->{'name'}: \n[" . DCBCommon::common_timestamp_time($first->{time}) . "] <$first_user->{name}>: $first->{chat}\n";
     }
     if (!$message) {
-      $message = $first_user->{'name'} . " has never spoken; boring!"
+      $message = $first_user->{'name'} . " has never spoken; boring!";
     }
   }
   else {

--- a/commands/last.pm
+++ b/commands/last.pm
@@ -28,7 +28,7 @@ sub main {
       $message = "Most recent line spoken by $first_user->{'name'}: \n[" . DCBCommon::common_timestamp_time($first->{time}) . "] <$first_user->{name}>: $first->{chat}\n";
     }
     if (!$message) {
-      $message = $first_user->{'name'} . " has never spoken; boring!"
+      $message = $first_user->{'name'} . " has never spoken; boring!";
     }
   }
   else {

--- a/commands/rmban.pm
+++ b/commands/rmban.pm
@@ -38,7 +38,7 @@ sub main {
     if (DCBSettings::config_get('ban_handler') =~ 'bot') {
       # We handle the unban in the bot rather than allow ODCH to handle
       my %where = ('uid' => $victim->{'uid'});
-      DCBDatabase::db_delete('ban', \%where)
+      DCBDatabase::db_delete('ban', \%where);
     }
     else {
       my @unnickban = (

--- a/commands/tell.pm
+++ b/commands/tell.pm
@@ -54,7 +54,7 @@ sub main {
       $message = "Message from $user->{name} to $to_user->{name} saved and will be delivered next time they $action";
     }
     else {
-      $message = "$to_user_name is not a user - no message saved."
+      $message = "$to_user_name is not a user - no message saved.";
     }
   }
   else {


### PR DESCRIPTION
## Summary
- Add missing semicolons in `first.pm`, `last.pm`, `tell.pm`, and `rmban.pm`
- These are syntax errors that would cause runtime crashes when the commands are invoked

## Files changed
- `commands/first.pm` - missing `;` after string assignment
- `commands/last.pm` - missing `;` after string assignment
- `commands/tell.pm` - missing `;` after string assignment
- `commands/rmban.pm` - missing `;` after `db_delete()` call

## Test plan
- [ ] All four commands parse without syntax errors
- [ ] `perl -c commands/first.pm` etc. pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)