### PR TITLE
Fix broken common_escape_string function

### DIFF
--- a/DCBCommon.pm
+++ b/DCBCommon.pm
@@ -219,8 +219,7 @@ sub commands_run_command {
 
 sub common_escape_string {
   my $string = shift;
-  $string =~ s/$_/$_/ for qw(\\\ \| \\( \\) \[ \{ \$ \+ \? \. \* \/ \^);
-  return $string;
+  return quotemeta($string);
 }
 
 sub common_timestamp_time {


### PR DESCRIPTION
## Summary
- Replace broken regex escaping logic with Perl's built-in `quotemeta()`
- The old implementation `s/$_/$_/` replaced each character with itself (a no-op)
- `quotemeta()` properly escapes all regex metacharacters

## Test plan
- [ ] Command prefix character is properly escaped for use in regex matching
- [ ] Special characters like `+`, `*`, `.` are properly escaped

Generated with [Claude Code](https://claude.com/claude-code)