### PR TITLE
Fix incorrect hash initialization in opchat

### DIFF
--- a/opchat.pl
+++ b/opchat.pl
@@ -23,7 +23,7 @@ use DCBUser;
 Log::Log4perl->init('opchat.log4perl.conf');
 my $logger = Log::Log4perl->get_logger('OPChat');
 
-my $oplist = ();
+my $oplist = {};
 
 eval {
   our $Settings = new DCBSettings;


### PR DESCRIPTION
## Summary
- Initialize `$oplist` as empty hashref `{}` instead of empty list `()`
- Assigning `()` to a scalar gives `undef`, which would cause errors on first hash dereference
- `$oplist` is used as a hash reference throughout the file

## Test plan
- [ ] opchat starts without errors
- [ ] Adding/removing users from oplist works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)