### PR TITLE
Fix IP address validation regex in user checks

### DIFF
--- a/DCBUser.pm
+++ b/DCBUser.pm
@@ -174,7 +174,7 @@ sub user_check_errors($) {
   if ($DCBSettings::config->{minshare} > $user->{'connect_share'}) {
     push(@errors, "Your share is currently under the minimum share. The minimum share is currently " . DCBCommon::common_format_size($DCBSettings::config->{minshare}));
   }
-  if (!$DCBSettings::config->{allow_external} && $user->{'ip'} !~ 127.0.0.1) {
+  if (!$DCBSettings::config->{allow_external} && $user->{'ip'} !~ /^127\.0\.0\.1$/) {
     push(@errors, "External users are not currently accepted.");
   }
   if (!$DCBSettings::config->{allow_passive} && $user->{'client'} =~ /M:P,H/) {


### PR DESCRIPTION
## Summary
- Add missing regex delimiters to IP address comparison
- Escape dots (`.` → `\.`) so they match literal dots, not any character
- Anchor with `^` and `$` to match the full IP, not a substring

## Test plan
- [ ] Local users (127.0.0.1) are correctly identified
- [ ] External users are correctly identified when `allow_external` is disabled
- [ ] IPs like `127a0b0c1` no longer falsely match as local

🤖 Generated with [Claude Code](https://claude.com/claude-code)