### PR TITLE
Fix numeric sort and variable shadowing in winning command

### DIFF
--- a/commands/winning.pm
+++ b/commands/winning.pm
@@ -39,17 +39,17 @@ sub main {
       }
     }
   }
-  my $winners = "List of longest logged in users:\n";
-  foreach my $key (sort {$winners{$a} cmp $winners{$b}} keys %winners){
+  my $message = "List of longest logged in users:\n";
+  foreach my $key (sort {$winners{$a} <=> $winners{$b}} keys %winners){
     if ($limit) {
-      $winners .= "$key: " . DCBCommon::common_timestamp_duration($winners{$key}) . "\n";
+      $message .= "$key: " . DCBCommon::common_timestamp_duration($winners{$key}) . "\n";
       $limit--;
     }
   }
   @return = (
     {
       param    => "message",
-      message  => $winners,
+      message  => $message,
       user     => $user->{name},
       touser   => '',
       type     => MESSAGE->{'PUBLIC_SINGLE'},


### PR DESCRIPTION
## Summary
- Replace string comparison `cmp` with numeric `<=>` for sorting timestamps
- Rename scalar `$winners` to `$message` to eliminate confusing shadowing with `%winners` hash
- String comparison of timestamps produces wrong sort order (e.g., "9" > "10" as strings)

## Test plan
- [ ] Winning command displays users sorted by actual login duration
- [ ] Output message is correctly formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)