### PR TITLE
Update Travis CI to modern Perl versions and syntax checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: perl
 perl:
+  - "5.30"
+  - "5.28"
   - "5.26"
-  - "5.24"
-  - "5.22"
-  - "5.20"
 before_install:
   - cpanm Cwd
   - cpanm DateTime
@@ -32,4 +31,4 @@ before_script:
   - "perl ./odchbot.test"
   - "cp odchbot.yml.example odchbot.yml"
   - "cp opchat.yml.example opchat.yml"
-script: "perl ./odchbot.pl && perl ./opchat.pl"
+script: "perl -c ./odchbot.pl && perl -c ./opchat.pl && perl -c ./dragon.pl"


### PR DESCRIPTION
## Summary
- Update tested Perl versions from 5.20-5.26 to 5.26-5.30 (drop EOL versions)
- Replace `perl ./odchbot.pl` (which always exits 0) with `perl -c` syntax checking
- Add syntax check for `dragon.pl` alongside `odchbot.pl` and `opchat.pl`

## Test plan
- [ ] Travis CI builds pass with updated config
- [ ] Syntax errors in any `.pl` file would cause build failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)