### PR TITLE
Replace deprecated Switch module with if/elsif

### DIFF
--- a/DCBDatabase.pm
+++ b/DCBDatabase.pm
@@ -2,7 +2,6 @@ package DCBDatabase;
 
 use strict;
 use warnings;
-use Switch;
 use YAML::AppConfig;
 use DBI;
 use SQL::Abstract;
@@ -48,17 +47,15 @@ sub db_connect {
     die;
   }
 
-  switch ( $db->{driver} ) {
-    case /^SQLite/ {
+  if ($db->{driver} =~ /^SQLite/) {
       $dsn .= $DCBSettings::cwd . $db->{path} . '/' . $db->{database};
     }
-    case /^[mysql|Pg]/ {
+    elsif ($db->{driver} =~ /^[mysql|Pg]/) {
       $dsn .= "database=$db->{database};host=$db->{host};port=$db->{port}";
     }
     else {
       $dsn .= "$db->{database}:$db->{host}:$db->port";
     }
-  }
 
 # We could also move the initial db connection into here our $dbh = db_connect(); and then if that returns false we can attempt an install_db()
 # That would probably be quicker than the dodgy grep @tables method. Although with sqlite if you try and connect it creates it for you...
@@ -104,14 +101,12 @@ sub db_create_table {
             $install .= " PRIMARY KEY";
           }
           if ($fields->{$key}->{autoincrement}) {
-             switch ($DCBSettings::config->{db}->{driver}) {
-               case /^SQLite/ {
+             if ($DCBSettings::config->{db}->{driver} =~ /^SQLite/) {
                 $install .= " AUTOINCREMENT";
                }
-               case /^[mysql|Pg]/ {
+               elsif ($DCBSettings::config->{db}->{driver} =~ /^[mysql|Pg]/) {
                  $install .= " AUTO_INCREMENT";
                }
-            }
           }
           $install .= ", "
         }

--- a/commands/ban.pm
+++ b/commands/ban.pm
@@ -8,7 +8,6 @@ use DCBSettings;
 use DCBCommon;
 use DCBUser;
 use DCBDatabase;
-use Switch;
 
 sub schema {
   my %schema = (
@@ -237,13 +236,11 @@ sub ban_calculate_ban_time {
   # and our custom ban implementation.
   my @bantime = split(/(\d+)(\w?)/, shift);
   my $time = $bantime[1];
-  switch ($bantime[2]) {
-    case 'm' { $time *= 60; }
-    case 'h' { $time *= (60 * 60); }
-    case 'd' { $time *= (60 * 60 * 24); }
-    case 'w' { $time *= (60 * 60 * 24 * 7); }
-    case 'y' { $time *= (60 * 60 * 24 * 365); }
-  }
+  if ($bantime[2] eq 'm') { $time *= 60; }
+  elsif ($bantime[2] eq 'h') { $time *= (60 * 60); }
+  elsif ($bantime[2] eq 'd') { $time *= (60 * 60 * 24); }
+  elsif ($bantime[2] eq 'w') { $time *= (60 * 60 * 24 * 7); }
+  elsif ($bantime[2] eq 'y') { $time *= (60 * 60 * 24 * 365); }
 
   return $time;
 }

--- a/commands/config.pm
+++ b/commands/config.pm
@@ -4,7 +4,6 @@ use strict;
 use warnings;
 use FindBin;
 use lib "$FindBin::Bin/..";
-use Switch;
 use YAML::AppConfig;
 use DCBSettings;
 use DCBCommon;

--- a/commands/google.pm
+++ b/commands/google.pm
@@ -5,7 +5,6 @@ use strict;
 use warnings;
 use FindBin;
 use lib "$FindBin::Bin/..";
-use Switch;
 use DCBCommon;
 
 sub main{

--- a/dragon.pl
+++ b/dragon.pl
@@ -5,7 +5,6 @@ use warnings;
 
 #use Log::Log4perl qw(:easy); # Also gives additional debug info back from bot.
 use Net::Jabber::Bot;
-use Switch;
 use Text::Tabs;
 use utf8;
 binmode(STDOUT, ":utf8");
@@ -224,17 +223,15 @@ sub jabber_respond {
   my ($bot_hash, @return) = @_;
 
   foreach (@return) {
-    switch ($_->{param}) {
-      case "message" {
+    if ($_->{param} eq "message") {
         jabber_sendmessage($bot_hash, $_->{user}, $_->{fromuser}, $_->{type}, $_->{message});
       }
-#      case =~ "action" {
+#      elsif ($_->{param} eq "action") {
 #        #odch_odch($_->{action}, $_->{user}, $_->{arg});
 #      }
-#      case =~ "log" {
+#      elsif ($_->{param} eq "log") {
 #        #odch_debug($_->{action}, $_->{user}, $_->{arg});
 #      }
-    }
   }
 }
 
@@ -253,34 +250,11 @@ sub jabber_sendmessage {
   # https://code.google.com/p/perl-net-jabber-bot/issues/detail?id=24
   my $jid = $DCBCommon::COMMON->{jidmap}->{$bot_hash->{sender}}->{jid};
   foreach (split(/\n/, $message)) {
-    switch ($type) {
-#      case (MESSAGE->{'HUB_PUBLIC'}) { odch::data_to_all($message."|"); }
-
-      case (MESSAGE->{'PUBLIC_SINGLE'}) { $bot->SendPersonalMessage($jid, $_); }
-      case (MESSAGE->{'BOT_PM'}) { $bot->SendPersonalMessage($jid, $_); }
-      case (MESSAGE->{'PUBLIC_ALL'}) {
+    if ($type == MESSAGE->{'PUBLIC_SINGLE'}) { $bot->SendPersonalMessage($jid, $_); }
+      elsif ($type == MESSAGE->{'BOT_PM'}) { $bot->SendPersonalMessage($jid, $_); }
+      elsif ($type == MESSAGE->{'PUBLIC_ALL'}) {
         $bot->SendGroupMessage($bot_hash->{reply_to}, $_);
-#        odch::data_to_all("<$botname> $message|");
-#        my $bot = ();
-#        $bot->{uid} = 1 ;
-#        odch_hooks('line', $bot, $message);
       }
-#      case (MESSAGE->{'MASS_MESSAGE'}) { odch::data_to_all("\$To: $user From: $botname \$<$botname> $message|"); }
-#      case (MESSAGE->{'SPOOF_PM_BOTH'}) {
-#        odch::data_to_user($user,"\$To: $user From: $fromuser \$$message|");
-#        odch::data_to_user($fromuser,"\$To: $fromuser From: $user \$$message|");
-#      }
-#      case (MESSAGE->{'SEND_TO_OPS'}) { odch_sendtoops($botname, "$message|"); }
-#      case (MESSAGE->{'HUB_PM'}) { odch::data_to_user($user,"\$To: $user From: $botname \$$message|"); }
-#      case (MESSAGE->{'SPOOF_PM_SINGLE'}) { odch::data_to_user($user,"\$To: $user From: $fromuser \$<$fromuser> $message|"); }
-#      case (MESSAGE->{'SPOOF_PUBLIC'}) {
-#        odch::data_to_all("<$user> $message|");
-        #$DCBUser::userlist->{$name} name could be fake so put 0 here if need to
-#      }
-#      case (MESSAGE->{'RAW'}) { odch::data_to_user($user, $message."|"); }
-#      case (MESSAGE->{'SEND_TO_ADMINS'}) { odch_sendtoadmins($botname, "$message|"); }
-#      else { odch::data_to_all("<$botname> INCORRECT TYPE ERROR|"); }
-    }
   }
 }
 

--- a/odchbot.pl
+++ b/odchbot.pl
@@ -10,7 +10,6 @@ use warnings;
 
 use Time::HiRes qw(gettimeofday tv_interval);
 my $start_time = [gettimeofday()];
-use Switch;
 use Text::Tabs;
 use FindBin;
 use lib "$FindBin::Bin";
@@ -234,17 +233,15 @@ sub odch_respond {
   my @return = @_;
 
   foreach (@return) {
-    switch ($_->{param}) {
-      case "message" {
+    if ($_->{param} eq "message") {
         odch_sendmessage($_->{user}, $_->{fromuser}, $_->{type}, $_->{message});
       }
-      case "action" {
+      elsif ($_->{param} eq "action") {
         odch_odch($_->{action}, $_->{user}, $_->{arg});
       }
-      case "log" {
+      elsif ($_->{param} eq "log") {
         $logger->debug("Structure: ", { filter => \&Dumper, value  => $_ });
       }
-    }
   }
 }
 
@@ -260,27 +257,25 @@ sub odch_get {
 
 sub odch_odch {
   my($odch_func, $user, $arg) = @_;
-  switch($odch_func) {
-    case "kick" {
+  if ($odch_func eq "kick") {
       odch::kick_user($user);
     }
-    case "nickban" {
+    elsif ($odch_func eq "nickban") {
       odch::add_nickban_entry("$user $arg");
       odch::kick_user($user);
     }
-    case "unnickban" {
+    elsif ($odch_func eq "unnickban") {
       odch::remove_nickban_entry($user);
     }
-    case "gag" {
+    elsif ($odch_func eq "gag") {
       odch::add_gag_entry("$user $arg");
     }
-    case "ungag" {
+    elsif ($odch_func eq "ungag") {
       odch::remove_gag_entry($user);
     }
-    # case "set" {
+    # elsif ($odch_func eq "set") {
     #   odch::set_variable($arg);
     # }
-  }
 }
 
 sub hub_timer() {
@@ -297,32 +292,30 @@ sub odch_sendmessage {
   if ($message && $type && exists &odch::data_to_all) {
     my $botname = $DCBSettings::config->{botname};
 
-    switch ($type) {
-      case (MESSAGE->{'HUB_PUBLIC'}) { odch::data_to_all($message."|"); }
-      case (MESSAGE->{'PUBLIC_SINGLE'}) { odch::data_to_user($user, "<$botname> $message|"); }
-      case (MESSAGE->{'BOT_PM'}) { odch::data_to_user($user, "\$To: $user From: $botname \$<$botname> $message|"); }
-      case (MESSAGE->{'PUBLIC_ALL'}) {
+    if ($type == MESSAGE->{'HUB_PUBLIC'}) { odch::data_to_all($message."|"); }
+      elsif ($type == MESSAGE->{'PUBLIC_SINGLE'}) { odch::data_to_user($user, "<$botname> $message|"); }
+      elsif ($type == MESSAGE->{'BOT_PM'}) { odch::data_to_user($user, "\$To: $user From: $botname \$<$botname> $message|"); }
+      elsif ($type == MESSAGE->{'PUBLIC_ALL'}) {
         odch::data_to_all("<$botname> $message|");
         my $bot = ();
         $bot->{uid} = 1 ;
         odch_hooks('line', $bot, $message);
       }
-      case (MESSAGE->{'MASS_MESSAGE'}) { odch::data_to_all("\$To: $user From: $botname \$<$botname> $message|"); }
-      case (MESSAGE->{'SPOOF_PM_BOTH'}) {
+      elsif ($type == MESSAGE->{'MASS_MESSAGE'}) { odch::data_to_all("\$To: $user From: $botname \$<$botname> $message|"); }
+      elsif ($type == MESSAGE->{'SPOOF_PM_BOTH'}) {
         odch::data_to_user($user,"\$To: $user From: $fromuser \$$message|");
         odch::data_to_user($fromuser,"\$To: $fromuser From: $user \$$message|");
       }
-      case (MESSAGE->{'SEND_TO_OPS'}) { odch_sendtoops($botname, "$message|"); }
-      case (MESSAGE->{'HUB_PM'}) { odch::data_to_user($user,"\$To: $user From: $botname \$$message|"); }
-      case (MESSAGE->{'SPOOF_PM_SINGLE'}) { odch::data_to_user($user,"\$To: $user From: $fromuser \$<$fromuser> $message|"); }
-      case (MESSAGE->{'SPOOF_PUBLIC'}) {
+      elsif ($type == MESSAGE->{'SEND_TO_OPS'}) { odch_sendtoops($botname, "$message|"); }
+      elsif ($type == MESSAGE->{'HUB_PM'}) { odch::data_to_user($user,"\$To: $user From: $botname \$$message|"); }
+      elsif ($type == MESSAGE->{'SPOOF_PM_SINGLE'}) { odch::data_to_user($user,"\$To: $user From: $fromuser \$<$fromuser> $message|"); }
+      elsif ($type == MESSAGE->{'SPOOF_PUBLIC'}) {
         odch::data_to_all("<$user> $message|");
         #$DCBUser::userlist->{$name} name could be fake so put 0 here if need to
       }
-      case (MESSAGE->{'RAW'}) { odch::data_to_user($user, $message."|"); }
-      case (MESSAGE->{'SEND_TO_ADMINS'}) { odch_sendtoadmins($botname, "$message|"); }
+      elsif ($type == MESSAGE->{'RAW'}) { odch::data_to_user($user, $message."|"); }
+      elsif ($type == MESSAGE->{'SEND_TO_ADMINS'}) { odch_sendtoadmins($botname, "$message|"); }
       else { odch::data_to_all("<$botname> INCORRECT TYPE ERROR|"); }
-     }
   }
 }
 


### PR DESCRIPTION
## Summary
- Remove all usage of the deprecated `Switch` module (removed from Perl core in 5.36)
- Convert all `switch`/`case` statements to standard `if`/`elsif`/`else` chains
- Remove unused `use Switch` imports from `google.pm` and `config.pm`

## Files changed
- `odchbot.pl` - 3 switch statements converted
- `dragon.pl` - 2 switch statements converted
- `commands/ban.pm` - 1 switch statement converted
- `DCBDatabase.pm` - 2 switch statements converted
- `commands/google.pm` - unused import removed
- `commands/config.pm` - unused import removed

## Test plan
- [ ] Bot starts and processes messages correctly
- [ ] Ban time calculation works (minutes, hours, days, weeks, years)
- [ ] Database connection works for SQLite and MySQL/Pg
- [ ] All message types are dispatched correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)