### PR TITLE
Fix odch_hooks return value breaking prelogin checks

### DIFF
--- a/odchbot.pl
+++ b/odchbot.pl
@@ -216,6 +216,7 @@ sub odch_hooks {
     }
     odch_respond(@return);
   }
+  return @return;
 }
 
 sub odch_alter {
@@ -234,6 +235,7 @@ sub odch_respond {
   my @return = @_;
 
   foreach (@return) {
+    next unless ref $_ eq 'HASH' && defined $_->{param};
     switch ($_->{param}) {
       case "message" {
         odch_sendmessage($_->{user}, $_->{fromuser}, $_->{type}, $_->{message});


### PR DESCRIPTION
## Summary
- `odch_hooks()` did not explicitly return `@return`, causing its implicit return value to be non-empty. This made the prelogin check in `odch_login()` incorrectly reject all connecting users since `scalar(@prelogin) != 0` was always true.
- Adds a guard in `odch_respond` to skip non-HASH elements, preventing "Use of uninitialized value" warnings when hooks return undef.

## Root Cause
In Perl, a function's return value is the value of the last evaluated expression. When `odch_hooks` entered the `if` block, the last expression was `odch_respond(@return)` — but `odch_respond` returns whatever `foreach` yields (not necessarily empty). When `odch_login` calls `my @prelogin = odch_hooks('prelogin', $user)` and checks `scalar(@prelogin) != 0`, this non-empty return falsely indicated a prelogin rejection.

## Test plan
- [ ] Verify users can connect to the hub without being rejected by prelogin
- [ ] Verify no "Use of uninitialized value" warnings in bot logs
- [ ] Run integration tests confirming all commands respond correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)