### PR TITLE
Fix uninitialized disconnect_time warnings in info and winning

### DIFF
--- a/commands/info.pm
+++ b/commands/info.pm
@@ -58,7 +58,7 @@ sub main {
       $message .= "\nJoined: " . DCBCommon::common_timestamp_time($target->{join_time});
       $message .= "\nShare Difference: " . DCBCommon::common_format_size($target->{connect_share} - $target->{join_share});
       $message .= "\nClient: " . $target->{client};
-      $message .= "\nStatus: " . ($target->{connect_time} > $target->{disconnect_time} ? "Online for: " . DCBCommon::common_timestamp_duration($target->{connect_time}) : "Offline");
+      $message .= "\nStatus: " . (!$target->{disconnect_time} || $target->{connect_time} > $target->{disconnect_time} ? "Online for: " . DCBCommon::common_timestamp_duration($target->{connect_time}) : "Offline");
     }
   }
   else {

--- a/commands/winning.pm
+++ b/commands/winning.pm
@@ -34,7 +34,7 @@ sub main {
   foreach my $this_user (keys %{$DCBUser::userlist}) {
     $this_user = lc($this_user);
     if ($DCBUser::userlist->{$this_user}->{'join_time'}) {
-      if ($DCBUser::userlist->{$this_user}->{'connect_time'} > $DCBUser::userlist->{$this_user}->{'disconnect_time'}) {
+      if (!$DCBUser::userlist->{$this_user}->{'disconnect_time'} || $DCBUser::userlist->{$this_user}->{'connect_time'} > $DCBUser::userlist->{$this_user}->{'disconnect_time'}) {
         $winners{$this_user} = $DCBUser::userlist->{$this_user}->{'connect_time'};
       }
     }


### PR DESCRIPTION
## Summary
- Fixes "Use of uninitialized value in numeric gt" warnings in `info.pm` and `winning.pm`
- Users who are currently connected have `undef` for `disconnect_time`, causing warnings when comparing `connect_time > disconnect_time`
- Adds `!$target->{disconnect_time} ||` guard before the comparison (matching the pattern already used in the admin view of info.pm at line 52)

## Test plan
- [ ] Connect a user to the hub and run `!info` — no warnings in bot log
- [ ] Run `!winning` — no warnings in bot log
- [ ] Verify online users show "Online for: ..." and offline users show "Offline"

🤖 Generated with [Claude Code](https://claude.com/claude-code)