### PR TITLE
Fix missing import and broken shift in time command

### DIFF
--- a/commands/time.pm
+++ b/commands/time.pm
@@ -6,12 +6,12 @@ use FindBin;
 use lib "$FindBin::Bin/..";
 use Scalar::Util qw(looks_like_number);
 use DCBCommon;
+use DCBSettings;
 
 sub main {
   my $command = shift;
   my $user = shift;
-  my @chat = shift;
-  my $time = shift(@chat);
+  my $time = shift;
 
   my $message = '';
   my $timezone = DCBSettings::config_get('timezone');


### PR DESCRIPTION
## Summary
- Adds missing `use DCBSettings;` import — `config_get('timezone')` would fail at runtime without it
- Fixes incorrect `my @chat = shift; my $time = shift(@chat);` pattern — the chat parameter is a scalar, so assigning to an array then shifting back out is redundant and confusing. Changed to `my $time = shift;` directly.

## Test plan
- [ ] `!time` shows current time with timezone
- [ ] `!time 1234567890` converts the given epoch timestamp
- [ ] No runtime errors about DCBSettings

🤖 Generated with [Claude Code](https://claude.com/claude-code)