### PR TITLE
Add missing DCBSettings import in load command

### DIFF
--- a/commands/load.pm
+++ b/commands/load.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 use FindBin;
 use lib "$FindBin::Bin/..";
+use DCBSettings;
 use DCBUser;
 use DCBCommon;
 


### PR DESCRIPTION
## Summary
- `load.pm` uses `$DCBSettings::cwd` and `$DCBSettings::config->{commandPath}` to construct file paths but never imports the DCBSettings module
- Without the import, these variables are undefined, causing the `!load` command to fail when trying to load new commands at runtime

## Test plan
- [ ] `!load <command>` correctly loads a command from the commands directory
- [ ] No runtime errors about undefined DCBSettings variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)