### PR TITLE
Fix uninitialized disconnect_time in tell command

### DIFF
--- a/commands/tell.pm
+++ b/commands/tell.pm
@@ -50,7 +50,7 @@ sub main {
         'message' => $tell_message,
       );
       DCBDatabase::db_insert('tell', \%fields);
-      my $action = ($to_user->{connect_time} - $to_user->{disconnect_time} < 0) ? 'log on' : 'speak in chat';
+      my $action = (!$to_user->{disconnect_time} || $to_user->{connect_time} > $to_user->{disconnect_time}) ? 'speak in chat' : 'log on';
       $message = "Message from $user->{name} to $to_user->{name} saved and will be delivered next time they $action";
     }
     else {


### PR DESCRIPTION
## Summary
- `tell.pm` line 53 subtracts `disconnect_time` from `connect_time` to determine if the target user is online
- `disconnect_time` is `undef` for users who haven't disconnected yet, causing an "uninitialized value" warning
- Replaced with the standard guard pattern: `!$to_user->{disconnect_time} || $to_user->{connect_time} > $to_user->{disconnect_time}`
- Same fix pattern applied in PR #89 for info.pm and winning.pm

## Test plan
- [ ] `!tell <online_user> hello` correctly says "next time they speak in chat"
- [ ] `!tell <offline_user> hello` correctly says "next time they log on"
- [ ] No uninitialized value warnings in bot log

🤖 Generated with [Claude Code](https://claude.com/claude-code)