### PR TITLE
Implement gag and ungag commands

### DIFF
--- a/commands/gag.pm
+++ b/commands/gag.pm
@@ -4,21 +4,86 @@ use strict;
 use warnings;
 use FindBin;
 use lib "$FindBin::Bin/..";
+use DCBSettings;
 use DCBCommon;
+use DCBUser;
+
+sub schema {
+  my %schema = (
+    config => {
+      gag_default_time => 300,
+      gag_default_message => "You have been gagged",
+    },
+  );
+  return \%schema;
+}
 
 sub main {
   my $command = shift;
   my $user = shift;
-
+  my $botmessage = '';
   my @return = ();
+  my @chatarray = split(/\s+/, shift);
+
+  if (!@chatarray) {
+    $botmessage = "Usage: " . DCBSettings::config_get('cp') . "gag <username> [duration]";
+  }
+  else {
+    my $victimname = shift(@chatarray);
+    my $victim = $victimname ? $DCBUser::userlist->{lc($victimname)} : '';
+    my $gagtime = @chatarray ? shift(@chatarray) : DCBSettings::config_get('gag_default_time');
+    my $reason = @chatarray ? join(' ', @chatarray) : DCBSettings::config_get('gag_default_message');
+
+    if ($victim && $victim->{uid}) {
+      if ($user->{permission} >= $victim->{permission}) {
+        $botmessage = "$user->{name} has gagged $victimname for $gagtime seconds: $reason";
+
+        @return = (
+          {
+            param   => "message",
+            message => $botmessage,
+            user    => $victim->{name},
+            touser  => '',
+            type    => MESSAGE->{'PUBLIC_ALL'},
+          },
+          {
+            param   => "message",
+            message => "You have been gagged by $user->{name}: $reason",
+            user    => $victim->{name},
+            touser  => '',
+            type    => MESSAGE->{'BOT_PM'},
+          },
+          {
+            param  => "action",
+            user   => $victim->{name},
+            action => 'gag',
+            arg    => $gagtime,
+          },
+          {
+            param  => "log",
+            action => "gag",
+            arg    => $botmessage,
+            user   => $user,
+          },
+        );
+        return @return;
+      }
+      else {
+        $botmessage = DCBSettings::config_get('no_perms');
+      }
+    }
+    else {
+      $botmessage = "User does not exist or is offline.";
+    }
+  }
 
   @return = (
     {
-      param    => "message",
-      message  => "Placeholder for gag command",
-      user     => '',
-      touser   => '',
-      type     => MESSAGE->{'PUBLIC_ALL'},
+      param   => "message",
+      message => $botmessage,
+      user    => $user->{name},
+      touser  => '',
+      type    => MESSAGE->{'PUBLIC_ALL'},
     },
   );
   return @return;

--- a/commands/gag.yml
+++ b/commands/gag.yml
@@ -1,7 +1,6 @@
 name: gag
-description: Gag a specified user, additionally sending them a gag message
+description: Gag a specified user, preventing them from chatting
 required: 0
 permissions:
  - OPERATOR
  - ADMINISTRATOR
-

--- a/commands/ungag.pm
+++ b/commands/ungag.pm
@@ -1,0 +1,66 @@
+package ungag;
+
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/..";
+use DCBSettings;
+use DCBCommon;
+use DCBUser;
+
+sub main {
+  my $command = shift;
+  my $user = shift;
+  my @chatarray = split(/\s+/, shift);
+  my $victimname = @chatarray ? shift(@chatarray) : '';
+  my $botmessage = '';
+  my @return = ();
+
+  if (!$victimname) {
+    $botmessage = "Usage: " . DCBSettings::config_get('cp') . "ungag <username>";
+  }
+  else {
+    my $victim = $DCBUser::userlist->{lc($victimname)};
+    if ($victim && $victim->{uid}) {
+      $botmessage = "$user->{name} has ungagged $victimname";
+
+      @return = (
+        {
+          param   => "message",
+          message => $botmessage,
+          user    => $victim->{name},
+          touser  => '',
+          type    => MESSAGE->{'PUBLIC_ALL'},
+        },
+        {
+          param  => "action",
+          user   => $victim->{name},
+          action => 'ungag',
+        },
+        {
+          param  => "log",
+          action => "ungag",
+          arg    => $botmessage,
+          user   => $user,
+        },
+      );
+      return @return;
+    }
+    else {
+      $botmessage = "User does not exist or is offline.";
+    }
+  }
+
+  @return = (
+    {
+      param   => "message",
+      message => $botmessage,
+      user    => $user->{name},
+      touser  => '',
+      type    => MESSAGE->{'PUBLIC_ALL'},
+    },
+  );
+  return @return;
+}
+
+1;

--- a/commands/ungag.yml
+++ b/commands/ungag.yml
@@ -1,0 +1,6 @@
+name: ungag
+description: Remove a gag from a specified user
+required: 0
+permissions:
+ - OPERATOR
+ - ADMINISTRATOR


### PR DESCRIPTION
## Summary
- Replaces the placeholder `gag.pm` with a full implementation mirroring the ban command pattern
- Adds new `ungag` command to remove gags

### gag command
- Usage: `!gag <username> [duration] [reason]`
- Checks target exists and is online
- Verifies operator has sufficient permission (can't gag higher-ranked users)
- Sends gag action to OpenDCHub via `odch::add_gag_entry`
- PMs the victim with the gag reason
- Announces the gag publicly and logs the action
- Config defaults via schema: `gag_default_time` (300s), `gag_default_message`

### ungag command
- Usage: `!ungag <username>`
- Removes the gag via `odch::remove_gag_entry`
- Announces the ungag publicly and logs the action

## Test plan
- [ ] `!gag TestUser` gags user with default duration
- [ ] `!gag TestUser 600 being annoying` gags with custom duration and reason
- [ ] `!ungag TestUser` removes the gag
- [ ] Cannot gag users with higher permissions
- [ ] `!gag` without args shows usage message

🤖 Generated with [Claude Code](https://claude.com/claude-code)