### PR TITLE
Fix regex match used for alias dedup in commands list

### DIFF
--- a/commands/commands.pm
+++ b/commands/commands.pm
@@ -41,7 +41,7 @@ sub main {
   else {
     foreach my $commands (sort keys %{$DCBCommon::registry->{commands}}) {
       my $command = $DCBCommon::registry->{commands}->{$commands};
-      if ($commands =~ $DCBCommon::registry->{commands}->{$commands}->{name}) {
+      if ($commands eq $DCBCommon::registry->{commands}->{$commands}->{name}) {
         if (user_access($user, $command->{permissions})) {
           $message .= DCBCommon::common_escape_string("$DCBSettings::config->{cp}") . "$command->{name}: $command->{description}\n";
         }


### PR DESCRIPTION
## Summary
- `commands.pm` line 44 uses `=~` (regex match) instead of `eq` (string equality) to deduplicate aliases from the command list
- This is a filter to show each command only once (aliases have different registry keys but the same `name` field)
- Using `=~` works by accident for most names but would break if a command name contained regex metacharacters (e.g. `8ball` could match unexpected patterns since `.` matches any character in regex)
- Changed to `eq` which is both semantically correct and safe

## Test plan
- [ ] `!commands` lists all commands without duplicates
- [ ] Aliased commands (e.g. ban/tban) appear only once in the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)