### PR TITLE
Fix null victim dereference and undef disconnect_time in kick

### DIFF
--- a/commands/kick.pm
+++ b/commands/kick.pm
@@ -23,11 +23,12 @@ sub main {
   my @chatarray = split(/\s+/, shift);
   my $victim = @chatarray ? $DCBUser::userlist->{lc(shift(@chatarray))} : '';
   my $kickmessage = @chatarray ? join(' ', @chatarray) : DCBSettings::config_get('kick_default');
-  my $botmessage = "$user->{'name'} is kicking $victim->{'name'} because $kickmessage";
+  my $botmessage = '';
   my @return = ();
 
   # Check that the victim is actually a user who is online
-  if ($victim && ($victim->{'connect_time'} > $victim->{'disconnect_time'})) {
+  if ($victim && (!$victim->{'disconnect_time'} || $victim->{'connect_time'} > $victim->{'disconnect_time'})) {
+    $botmessage = "$user->{'name'} is kicking $victim->{'name'} because $kickmessage";
     # If the user is lower permission than the victim, make the kick fail
     if ($user->{'permission'} >= $victim->{'permission'}) {
       @return = (


### PR DESCRIPTION
## Summary
Two bugs in `kick.pm`:

1. **Null dereference** (line 26): `$botmessage` was constructed using `$victim->{name}` *before* checking if `$victim` exists. When a user specifies a non-existent target (e.g. `!kick FakeUser`), the userlist lookup returns `undef`, and `$victim->{'name'}` throws "Can't use string as HASH ref". Fixed by moving the botmessage construction inside the `if ($victim)` block.

2. **Undef disconnect_time** (line 30): The online check `$victim->{connect_time} > $victim->{disconnect_time}` warns when disconnect_time is undef (user hasn't disconnected yet). Added the standard `!$victim->{disconnect_time} ||` guard.

## Test plan
- [ ] `!kick NonexistentUser` returns "User does not exist" without crashing
- [ ] `!kick OnlineUser` kicks the user correctly
- [ ] No uninitialized value warnings in bot log

🤖 Generated with [Claude Code](https://claude.com/claude-code)