### PR TITLE
Remove unused Switch import from coin.pm

### DIFF
--- a/commands/coin.pm
+++ b/commands/coin.pm
@@ -4,7 +4,6 @@ use strict;
 use warnings;
 use FindBin;
 use lib "$FindBin::Bin/..";
-use Switch;
 use DCBCommon;
 
 sub main {


### PR DESCRIPTION
## Summary
- PR #86 removed `use Switch` from 6 files but missed `coin.pm`
- `coin.pm` doesn't use any switch/case syntax — it's a dead import
- On Perl 5.14+ (where Switch was removed from core), this kills the entire bot since DCBCommon loads all commands during init

This is the last remaining blocker for the CI integration tests.

## Test plan
- [ ] Verify coin.pm compiles cleanly
- [ ] Verify bot loads and `-coin` command works

🤖 Generated with [Claude Code](https://claude.com/claude-code)