### PR TITLE
Update CI Perl matrix to 5.34, 5.38, 5.40

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        perl-version: ['5.26', '5.30', '5.34']
+        perl-version: ['5.34', '5.38', '5.40']
 
     name: Perl ${{ matrix.perl-version }}
     steps:


### PR DESCRIPTION
## Summary
- Drop EOL Perl 5.26 and 5.30 from the CI matrix
- Add Perl 5.38 and 5.40, the current stable releases
- Retain Perl 5.34 as the oldest supported version

## Test plan
- [ ] Verify CI passes on all three Perl versions (5.34, 5.38, 5.40)

🤖 Generated with [Claude Code](https://claude.com/claude-code)