### PR TITLE
Add cpanfile for dependency management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,29 +23,7 @@ jobs:
           perl-version: ${{ matrix.perl-version }}
 
       - name: Install CPAN dependencies
-        run: |
-          cpanm --notest \
-            Cwd \
-            DateTime \
-            DateTime::Duration \
-            DateTime::Format::Duration \
-            DBI \
-            DBD::SQLite \
-            Exporter \
-            JSON \
-            IPC::System::Simple \
-            Log::Log4perl \
-            Mail::Sendmail \
-            Module::Load \
-            Number::Bytes::Human \
-            SQL::Abstract \
-            Storable \
-            Text::Tabs \
-            WWW::TheMovieDB \
-            XML::Simple \
-            YAML \
-            YAML::AppConfig \
-            YAML::Syck
+        run: cpanm --installdeps --notest .
 
       - name: Syntax check (load all modules)
         run: perl ./odchbot.test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           perl-version: ${{ matrix.perl-version }}
 
       - name: Install CPAN dependencies
-        run: cpanm --installdeps --notest .
+        run: cpanm --installdeps --notest --with-feature=commands .
 
       - name: Syntax check (load all modules)
         run: perl ./odchbot.test

--- a/cpanfile
+++ b/cpanfile
@@ -1,0 +1,33 @@
+# Core bot dependencies
+requires 'DateTime';
+requires 'DateTime::Duration';
+requires 'DateTime::Format::Duration';
+requires 'DBI';
+requires 'DBD::SQLite';
+requires 'JSON';
+requires 'Log::Log4perl';
+requires 'Log::Dispatch::File';
+requires 'Module::Load';
+requires 'Number::Bytes::Human';
+requires 'SQL::Abstract';
+requires 'YAML';
+requires 'YAML::AppConfig';
+requires 'YAML::Syck';
+
+# Command-specific dependencies
+feature 'commands', 'Optional modules used by individual commands' => sub {
+    requires 'Clone';
+    requires 'HTTP::Request';
+    requires 'IPC::System::Simple';
+    requires 'LWP::Simple';
+    requires 'LWP::UserAgent';
+    requires 'Mail::Sendmail';
+    requires 'URI::Escape';
+    requires 'WWW::TheMovieDB';
+    requires 'XML::Simple';
+};
+
+# Jabber/XMPP bridge (dragon.pl)
+feature 'jabber', 'Net::Jabber::Bot for the XMPP bridge' => sub {
+    requires 'Net::Jabber::Bot';
+};


### PR DESCRIPTION
## Summary
- Add a `cpanfile` listing all external CPAN dependencies (core bot + optional command/bridge modules via `feature` blocks)
- Replace the inline `cpanm` dependency list in CI with `cpanm --installdeps --notest .`
- Core Perl modules are excluded from the cpanfile since they ship with Perl

## Test plan
- [ ] CI passes on all three Perl versions (5.26, 5.30, 5.34)
- [ ] `cpanm --installdeps .` installs all required modules on a fresh system
- [ ] `cpanm --installdeps --with-feature=commands .` also installs command-specific modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)