### PR TITLE
Drop abandoned SQL::Abstract::Limit dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,6 @@ jobs:
             Module::Load \
             Number::Bytes::Human \
             SQL::Abstract \
-            SQL::Abstract::Limit \
             Storable \
             Text::Tabs \
             WWW::TheMovieDB \

--- a/DCBDatabase.pm
+++ b/DCBDatabase.pm
@@ -5,7 +5,6 @@ use warnings;
 use YAML::AppConfig;
 use DBI;
 use SQL::Abstract;
-use SQL::Abstract::Limit;
 
 use Exporter;
 our @ISA = qw( Exporter );
@@ -143,8 +142,16 @@ sub db_select {
   my $order  = shift;
   my $limit  = shift;
   my $offset = shift;
-  my $sql = SQL::Abstract::Limit->new( limit_dialect => $DCBDatabase::dbh );
-  my ( $stmt, @bind ) = $sql->select( $table, $fields, $where, $order, $limit, $offset );
+  my $sql = SQL::Abstract->new;
+  my ( $stmt, @bind ) = $sql->select( $table, $fields, $where, $order );
+  if (defined $limit) {
+    $stmt .= " LIMIT ?";
+    push @bind, $limit;
+    if (defined $offset) {
+      $stmt .= " OFFSET ?";
+      push @bind, $offset;
+    }
+  }
   return db_execute( $stmt, @bind );
 }
 


### PR DESCRIPTION
## Summary
- Remove `SQL::Abstract::Limit` (unmaintained since 2015) from `DCBDatabase.pm` and CI workflow
- Replace with plain `SQL::Abstract` plus manual `LIMIT ?` / `OFFSET ?` appending
- LIMIT/OFFSET is standard SQL supported by all three drivers (SQLite, MySQL, PostgreSQL)

## Test plan
- [ ] CI passes (syntax check + boot test) without `SQL::Abstract::Limit` installed
- [ ] Commands that use `db_select` with limit/offset (e.g. `!seen`, `!top`) return correct results

🤖 Generated with [Claude Code](https://claude.com/claude-code)