### PR TITLE
Strengthen config file permission check

### DIFF
--- a/DCBSettings.pm
+++ b/DCBSettings.pm
@@ -21,11 +21,11 @@ sub config_load {
   my $config = shift // $config_file;
   our ( $settings, $cwd, $suffix ) = fileparse( abs_path(__FILE__) );
 
-  # Check file permissions - warn if config is readable by group/others
+  # Check file permissions - warn if config is accessible by group/others
   my $config_path = $cwd . $config;
   my $mode = (stat($config_path))[2];
-  if (defined $mode && ($mode & 044)) {
-    warn "WARNING: Config file $config_path is readable by group/others. "
+  if (defined $mode && ($mode & 0077)) {
+    warn "WARNING: Config file $config_path has group/other permissions set. "
        . "Consider running: chmod 600 $config_path\n";
   }
 


### PR DESCRIPTION
## Summary
- Widen the permission mask in `DCBSettings.pm` from `044` (read-only check) to `0077` (any group/other access)
- This catches write and execute permissions in addition to read, since config files may contain database credentials and should be owner-only
- Updated the warning message to reflect the broader check

## Test plan
- [ ] Verify warning triggers when config file has any group/other permission bits set (e.g., `chmod 644`, `chmod 610`)
- [ ] Verify no warning when config file is `chmod 600`

🤖 Generated with [Claude Code](https://claude.com/claude-code)