### PR TITLE
Graceful error recovery in database query layer

### DIFF
--- a/DCBDatabase.pm
+++ b/DCBDatabase.pm
@@ -165,17 +165,28 @@ sub db_delete( $ % ) {
   return db_execute( $stmt, @bind );
 }
 
-sub db_do( $ ) {
+sub db_do {
   my $query = shift;
-  return $DCBDatabase::dbh->do($query)
-    || die("Unable to complete query: $DBI::errstr");
+  my $rv = eval { $DCBDatabase::dbh->do($query) };
+  if (!defined $rv) {
+    warn "Unable to complete query: " . ($DBI::errstr // $@);
+    return;
+  }
+  return $rv;
 }
 
 sub db_execute {
   my ( $stmt, @bind ) = @_;
-  my $sth = $DCBDatabase::dbh->prepare($stmt)
-    || die "Couldn't prepare statement: " . $DCBDatabase::dbh->errstr;
-  $sth->execute(@bind) || die "Couldn't execute statement: " . $sth->errstr;
+  my $sth = eval { $DCBDatabase::dbh->prepare($stmt) };
+  if (!$sth) {
+    warn "Couldn't prepare statement: " . ($DCBDatabase::dbh->errstr // $@);
+    return;
+  }
+  my $rv = eval { $sth->execute(@bind) };
+  if (!$rv) {
+    warn "Couldn't execute statement: " . ($sth->errstr // $@);
+    return;
+  }
   return $sth;
 }
 


### PR DESCRIPTION
## Summary
- Replace `die` with `warn` + `return` in `db_execute` and `db_do` so a single failed query no longer crashes the entire long-running bot process
- Wrap DBI calls in `eval` blocks to catch exceptions and log them as warnings
- `db_connect` retains `die` behavior since the bot cannot function without a database connection

## Test plan
- [ ] Verify bot starts normally and existing commands work (SELECT/INSERT/UPDATE/DELETE paths through `db_execute`)
- [ ] Simulate a bad query and confirm the bot logs a warning but continues running
- [ ] Confirm `db_connect` still dies on connection failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)