### PR TITLE
Use semver for odchbot and opchat versions

### DIFF
--- a/odchbot.yml.example
+++ b/odchbot.yml.example
@@ -29,4 +29,4 @@ config:
   timezone: Australia/Canberra
   username_anonymous: Anonymous
   username_max_length: 35
-  version: v3
+  version: 3.0.0

--- a/opchat.yml.example
+++ b/opchat.yml.example
@@ -9,4 +9,4 @@ config:
   cp: "-"
   debug: 1
   topic: Welcome to OPChat
-  version: v1
+  version: 1.0.0


### PR DESCRIPTION
## Summary
- odchbot: `v3` → `3.0.0`
- opchat: `v1` → `1.0.0`

Switches from informal version strings to proper semver in the YAML config examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)