### PR TITLE
Fix escaped command prefix in display output

### DIFF
--- a/commands/commands.pm
+++ b/commands/commands.pm
@@ -20,7 +20,7 @@ sub main {
 
   if ($specific && $DCBCommon::registry->{commands}->{$specific} && (user_access($user, $DCBCommon::registry->{commands}->{$specific}->{permissions}))) {
     my $command = $DCBCommon::registry->{commands}->{$specific};
-    $message .= DCBCommon::common_escape_string("$DCBSettings::config->{cp}") . "$command->{name}: $command->{description}";
+    $message .= $DCBSettings::config->{cp} . "$command->{name}: $command->{description}";
     if ($command->{alias}) {
       $message .= "\nAliases: ";
       my $aliases = thaw($command->{alias});
@@ -43,7 +43,7 @@ sub main {
       my $command = $DCBCommon::registry->{commands}->{$commands};
       if ($commands eq $DCBCommon::registry->{commands}->{$commands}->{name}) {
         if (user_access($user, $command->{permissions})) {
-          $message .= DCBCommon::common_escape_string("$DCBSettings::config->{cp}") . "$command->{name}: $command->{description}\n";
+          $message .= $DCBSettings::config->{cp} . "$command->{name}: $command->{description}\n";
         }
       }
     }

--- a/odchbot.yml.example
+++ b/odchbot.yml.example
@@ -29,4 +29,4 @@ config:
   timezone: Australia/Canberra
   username_anonymous: Anonymous
   username_max_length: 35
-  version: 3.0.0
+  version: 3.0.1


### PR DESCRIPTION
## Summary
`commands.pm` used `common_escape_string` (quotemeta) on the command prefix for display text, turning `-` into `\-` in the commands list. The escaped form is only needed for regex matching (`$::c`), not display.

Bumps version to 3.0.1.

## Test plan
- [ ] `-commands` should show `-alert`, `-ban` etc. (no backslash)
- [ ] `-commands alert` should show `-alert:` (no backslash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)