### PR TITLE
Hardcode version in .pl files instead of YAML config

### DIFF
--- a/commands/update.pm
+++ b/commands/update.pm
@@ -16,7 +16,7 @@ sub main {
   # Use list form to prevent shell injection via config values
   my $old_dir = Cwd::getcwd();
   chdir($DCBSettings::cwd) or die "Cannot chdir to $DCBSettings::cwd: $!";
-  $output = capture("git", "pull", "origin", $DCBSettings::config->{version});
+  $output = capture("git", "pull");
   chdir($old_dir) or die "Cannot chdir back to $old_dir: $!";
   # temporarily removing the git log from the output as first time clones will not be able to run it
   #; " . 'git log @{1}..  --oneline');

--- a/odchbot.pl
+++ b/odchbot.pl
@@ -20,6 +20,8 @@ use DCBDatabase;
 use DCBCommon;
 use DCBUser;
 
+our $VERSION = '3.0.1';
+
 # Enable the logger and load configuration.
 # Read config and resolve relative paths against the script's directory so
 # the embedded Perl inside opendchub works regardless of the hub's CWD.
@@ -79,8 +81,8 @@ sub main() {
   odch::register_script_name($DCBSettings::config->{botname});
   odch_sendmessage("","",1,"\$HubName $DCBSettings::config->{topic}");
   my $loadtime = tv_interval ( $start_time ) ;
-  odch_sendmessage("","",4,"$DCBSettings::config->{botname} version $DCBSettings::config->{version} - loaded in $loadtime seconds!");
-  $logger->debug("$DCBSettings::config->{botname} version $DCBSettings::config->{version} - loaded in $loadtime seconds!");
+  odch_sendmessage("","",4,"$DCBSettings::config->{botname} version $VERSION - loaded in $loadtime seconds!");
+  $logger->debug("$DCBSettings::config->{botname} version $VERSION - loaded in $loadtime seconds!");
 }
 
 sub data_arrival() {
@@ -180,7 +182,7 @@ sub odch_login() {
     return;
   }
 
-  my $tag = "$DCBSettings::config->{bottag} V:$DCBSettings::config->{version},M:P,H:1/3/3,S:7";
+  my $tag = "$DCBSettings::config->{bottag} V:$VERSION,M:P,H:1/3/3,S:7";
   odch_sendmessage($user->{name}, "", 11, "\$MyINFO \$ALL $DCBSettings::config->{botname} " .
     "$DCBSettings::config->{botdescription}<$tag>\$\$\$$DCBSettings::config->{botspeed}>" .
     "\$$DCBSettings::config->{botemail}\$$DCBSettings::config->{botshare}\$");

--- a/odchbot.yml.example
+++ b/odchbot.yml.example
@@ -29,4 +29,3 @@ config:
   timezone: Australia/Canberra
   username_anonymous: Anonymous
   username_max_length: 35
-  version: 3.0.1

--- a/opchat.pl
+++ b/opchat.pl
@@ -19,6 +19,8 @@ use DCBCommon;
 use DCBSettings;
 use DCBUser;
 
+our $VERSION = '1.0.0';
+
 # Enable the logger and load configuration.
 # Read config and resolve relative paths against the script's directory so
 # the embedded Perl inside opendchub works regardless of the hub's CWD.
@@ -52,7 +54,7 @@ sub main {
   our $c = DCBCommon::common_escape_string("$DCBSettings::config->{cp}");
   odch::register_script_name($DCBSettings::config->{botname});
   my $loadtime = tv_interval ( $start_time ) ;
-  $logger->debug("$DCBSettings::config->{botname} version $DCBSettings::config->{version} - loaded in $loadtime seconds!");
+  $logger->debug("$DCBSettings::config->{botname} version $VERSION - loaded in $loadtime seconds!");
 }
 
 sub data_arrival {
@@ -154,7 +156,7 @@ sub opchat_login {
     $oplist->{lc($name)} = \%user;
   }
 
-  my $tag = "$DCBSettings::config->{bottag} V:$DCBSettings::config->{version},M:P,H:1/3/3,S:7";
+  my $tag = "$DCBSettings::config->{bottag} V:$VERSION,M:P,H:1/3/3,S:7";
   my $botmessage = "\$MyINFO \$ALL $DCBSettings::config->{botname} " .
     "$DCBSettings::config->{botdescription}<$tag>\$\$\$$DCBSettings::config->{botspeed}>" .
     "\$$DCBSettings::config->{botemail}\$$DCBSettings::config->{botshare}\$";

--- a/opchat.yml.example
+++ b/opchat.yml.example
@@ -9,4 +9,3 @@ config:
   cp: "-"
   debug: 1
   topic: Welcome to OPChat
-  version: 1.0.0


### PR DESCRIPTION
## Summary
- Adds `our $VERSION` to `odchbot.pl` (3.0.1) and `opchat.pl` (1.0.0) as hardcoded source-controlled values
- Replaces all `$DCBSettings::config->{version}` references with `$VERSION`
- Removes `version:` key from `odchbot.yml.example` and `opchat.yml.example`
- Simplifies `update.pm` to use `git pull` from tracking branch instead of pulling a branch named after the version string

## Test plan
- [ ] Verify Dragon shows correct version in tag and startup message
- [ ] Verify OPChat shows correct version in tag
- [ ] Verify `-update` command works (pulls from tracking branch)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)